### PR TITLE
Add sanitizeLinkRewrite tests

### DIFF
--- a/tests/sanitizeLinkRewrite.test.ts
+++ b/tests/sanitizeLinkRewrite.test.ts
@@ -1,0 +1,19 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import { sanitizeLinkRewrite } from '../lib/prestashop-api'
+
+test('conversion a minusculas y reemplazo de espacios por guiones', () => {
+  assert.strictEqual(sanitizeLinkRewrite('Hello World'), 'hello-world')
+  assert.strictEqual(sanitizeLinkRewrite('Multiple   Spaces'), 'multiple-spaces')
+})
+
+test('eliminacion de caracteres no alfanumericos y guiones duplicados', () => {
+  assert.strictEqual(sanitizeLinkRewrite('Hello !@# World--123'), 'hello-world-123')
+  assert.strictEqual(sanitizeLinkRewrite('Clean___this'), 'clean___this')
+})
+
+test('manejo de cadenas vacias', () => {
+  assert.strictEqual(sanitizeLinkRewrite(''), '')
+  assert.strictEqual(sanitizeLinkRewrite('   '), '')
+  assert.strictEqual(sanitizeLinkRewrite(String()), '')
+})


### PR DESCRIPTION
## Summary
- add a test folder with `sanitizeLinkRewrite.test.ts`
- test lowercase and space replacement
- test removal of invalid characters and duplicate hyphens
- test empty string handling

## Testing
- `npx tsc tests/sanitizeLinkRewrite.test.ts lib/prestashop-api.ts --module commonjs --target es2022 --outDir tests-dist --moduleResolution node --esModuleInterop --noEmitOnError false`
- `node tests-dist/tests/sanitizeLinkRewrite.test.js`
- `npm install --ignore-scripts --no-audit --no-fund` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68400e0cc1188330ba601ac6e6ff3de7