### PR TITLE
Fix alert exports and route params

### DIFF
--- a/app/api/prestashop/[...path]/route.ts
+++ b/app/api/prestashop/[...path]/route.ts
@@ -51,25 +51,34 @@ async function handleRequest(
 // Métodos HTTP soportados
 export async function GET(
     req: NextRequest,
-    context: { params: { path: string[] } }
+    { params }: { params: { path: string[] } },
 ) {
-    const pathSegments = context.params.path;
+    const pathSegments = params.path;
     return await handleRequest(req, 'GET', pathSegments);
 }
 
-export async function POST(req: NextRequest, context: { params: { path: string[] } }) {
+export async function POST(
+    req: NextRequest,
+    { params }: { params: { path: string[] } },
+) {
     const body = await req.text();
-    const pathSegments = context.params.path;
+    const pathSegments = params.path;
     return await handleRequest(req, 'POST', pathSegments, body);
 }
 
-export async function PUT(req: NextRequest, context: { params: { path: string[] } }) {
+export async function PUT(
+    req: NextRequest,
+    { params }: { params: { path: string[] } },
+) {
     const body = await req.text();
-    const pathSegments = context.params.path;
+    const pathSegments = params.path;
     return await handleRequest(req, 'PUT', pathSegments, body);
 }
 
-export async function DELETE(req: NextRequest, context: { params: { path: string[] } }) {
-    const pathSegments = context.params.path;
+export async function DELETE(
+    req: NextRequest,
+    { params }: { params: { path: string[] } },
+) {
+    const pathSegments = params.path;
     return await handleRequest(req, 'DELETE', pathSegments);
 }

--- a/components/ui/alert.tsx
+++ b/components/ui/alert.tsx
@@ -30,7 +30,10 @@ interface AlertProps extends React.HTMLAttributes<HTMLDivElement>, VariantProps<
 }
 
 const Alert = forwardRef<HTMLDivElement, AlertProps>(
-  ({ className, variant, title, dismissible = false, onDismiss, children, ...props }, ref) => {
+  (
+    { className, variant, title, dismissible = false, onDismiss, children, ...props },
+    ref,
+  ) => {
     const icons = {
       default: Info,
       destructive: AlertCircle,
@@ -61,4 +64,20 @@ const Alert = forwardRef<HTMLDivElement, AlertProps>(
 )
 Alert.displayName = "Alert"
 
-export { Alert, alertVariants }
+const AlertTitle = forwardRef<
+  HTMLHeadingElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5 ref={ref} className={cn("font-medium mb-1", className)} {...props} />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <p ref={ref} className={cn("text-sm", className)} {...props} />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, alertVariants, AlertTitle, AlertDescription }


### PR DESCRIPTION
## Summary
- add `AlertTitle` and `AlertDescription` utilities
- fix dynamic API route to destructure params

## Testing
- `node --test tests/sanitizeLinkRewrite.test.ts` *(fails: ERR_UNKNOWN_FILE_EXTENSION)*
- `pnpm lint` *(fails: next not found)*
- `pnpm dev` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401411e01c8330aa7456cc6252264e