### PR TITLE
Fix build hooks and breadcrumb imports

### DIFF
--- a/app/product-prestashop/[id]/page.tsx
+++ b/app/product-prestashop/[id]/page.tsx
@@ -8,17 +8,10 @@ import { Card, CardContent } from "@/components/ui/card"
 import { Badge } from "@/components/ui/badge"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb"
+import { Breadcrumb } from "@/components/ui/breadcrumb"
 import { Header } from "@/components/layout/Header"
 import { Footer } from "@/components/ui/footer"
-import { usePrestashopProduct } from "@/hooks/usePrestashopProducts"
+import { usePrestashopProduct } from "@/hooks/usePrestashopProduct"
 import { usePrestashopCart } from "@/hooks/usePrestashopCart"
 import { useToast } from "@/hooks/use-toast"
 import Link from "next/link"
@@ -105,21 +98,14 @@ export default function PrestashopProductPage() {
 
       <main className="container mx-auto px-4 py-8">
         {/* Breadcrumb */}
-        <Breadcrumb className="mb-6">
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/">Inicio</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/products-prestashop">Productos</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>{product.name}</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
+        <Breadcrumb
+          items={[
+            { label: "Inicio", href: "/" },
+            { label: "Productos", href: "/products-prestashop" },
+            { label: product.name },
+          ]}
+          className="mb-6"
+        />
 
         {/* Back Button */}
         <Link href="/products-prestashop">

--- a/app/products-prestashop/page.tsx
+++ b/app/products-prestashop/page.tsx
@@ -5,14 +5,7 @@ import { Header } from "@/components/layout/Header"
 import { Footer } from "@/components/ui/footer"
 import { PrestashopProductGrid } from "@/components/prestashop/PrestashopProductGrid"
 import { LoadingSpinner } from "@/components/ui/loading-spinner"
-import {
-  Breadcrumb,
-  BreadcrumbItem,
-  BreadcrumbLink,
-  BreadcrumbList,
-  BreadcrumbPage,
-  BreadcrumbSeparator,
-} from "@/components/ui/breadcrumb"
+import { Breadcrumb } from "@/components/ui/breadcrumb"
 
 export default function PrestashopProductsPage() {
   return (
@@ -21,17 +14,13 @@ export default function PrestashopProductsPage() {
 
       <main className="container mx-auto px-4 py-8">
         {/* Breadcrumb */}
-        <Breadcrumb className="mb-6">
-          <BreadcrumbList>
-            <BreadcrumbItem>
-              <BreadcrumbLink href="/">Inicio</BreadcrumbLink>
-            </BreadcrumbItem>
-            <BreadcrumbSeparator />
-            <BreadcrumbItem>
-              <BreadcrumbPage>Productos PrestaShop</BreadcrumbPage>
-            </BreadcrumbItem>
-          </BreadcrumbList>
-        </Breadcrumb>
+        <Breadcrumb
+          items={[
+            { label: "Inicio", href: "/" },
+            { label: "Productos PrestaShop" },
+          ]}
+          className="mb-6"
+        />
 
         {/* Page Header */}
         <div className="mb-8">

--- a/app/responsive-category/page.tsx
+++ b/app/responsive-category/page.tsx
@@ -1,3 +1,5 @@
+"use client"
+
 import { Filter, Grid, List } from "lucide-react"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"

--- a/hooks/usePrestashopProduct.ts
+++ b/hooks/usePrestashopProduct.ts
@@ -1,0 +1,68 @@
+"use client"
+
+import { useState, useCallback, useEffect } from "react"
+import { productsAPI, getCachedData, setCachedData } from "@/lib/prestashop-api"
+import type { Product } from "@/types"
+
+export function usePrestashopProduct(id: string) {
+  const [product, setProduct] = useState<Product | null>(null)
+  const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const loadProduct = useCallback(async () => {
+    try {
+      setIsLoading(true)
+      setError(null)
+
+      const cacheKey = `prestashop-product-${id}`
+      const cached = getCachedData<Product>(cacheKey)
+      if (cached) {
+        setProduct(cached)
+        setIsLoading(false)
+        return
+      }
+
+      const fetched = await productsAPI.getProduct(id)
+      setProduct(fetched)
+      setCachedData(cacheKey, fetched)
+    } catch (err) {
+      const errorMessage = err instanceof Error ? err.message : "Error al cargar producto"
+      setError(errorMessage)
+      console.error("Error loading product:", err)
+
+      const fallback: Product = {
+        id,
+        name: "Producto de Ejemplo",
+        description: "Producto de ejemplo mientras se conecta con PrestaShop",
+        price: 0,
+        category: "",
+        brand: "",
+        image: "/placeholder.svg?height=300&width=300&text=Producto",
+        images: ["/placeholder.svg?height=300&width=300&text=Producto"],
+        href: `/product/${id}`,
+        linkRewrite: "",
+        slug: "",
+        inStock: true,
+        stockQuantity: 1,
+        rating: 4.5,
+        reviewCount: 0,
+        isPrescriptionRequired: false,
+        tags: [],
+        specifications: {},
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      }
+      setProduct(fallback)
+    } finally {
+      setIsLoading(false)
+    }
+  }, [id])
+
+  useEffect(() => {
+    loadProduct()
+  }, [loadProduct])
+
+  const clearError = () => setError(null)
+
+  return { product, isLoading, error, refresh: loadProduct, clearError }
+}


### PR DESCRIPTION
## Summary
- add `usePrestashopProduct` hook
- update responsive category page to be a client component
- update product and products pages to use new breadcrumb API

## Testing
- `pnpm test` *(fails: no output)*
- `pnpm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684016d8d5d88330af50901753c98f38