### PR TITLE
Integrate Prestashop auth modal

### DIFF
--- a/app/account/orders/page.tsx
+++ b/app/account/orders/page.tsx
@@ -5,14 +5,14 @@ import { Package, Truck, CheckCircle, Clock, ArrowLeft } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { useAuth } from "@/hooks/useAuth"
+import { usePrestashopAuth } from "@/hooks/usePrestashopAuth"
 import { api } from "@/lib/api"
 import type { Order } from "@/types"
 import Link from "next/link"
 import { Header } from "@/components/layout/Header"
 
 export default function OrdersPage() {
-  const { state: authState } = useAuth()
+  const { state: authState } = usePrestashopAuth()
   const [orders, setOrders] = useState<Order[]>([])
   const [isLoading, setIsLoading] = useState(true)
 

--- a/app/account/page.tsx
+++ b/app/account/page.tsx
@@ -5,14 +5,14 @@ import { User, Package, MapPin, Settings, CreditCard, Heart } from "lucide-react
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
-import { useAuth } from "@/hooks/useAuth"
+import { usePrestashopAuth } from "@/hooks/usePrestashopAuth"
 import { api } from "@/lib/api"
 import type { Order } from "@/types"
 import Link from "next/link"
 import { Header } from "@/components/layout/Header"
 
 export default function AccountPage() {
-  const { state: authState } = useAuth()
+  const { state: authState } = usePrestashopAuth()
   const [recentOrders, setRecentOrders] = useState<Order[]>([])
   const [isLoading, setIsLoading] = useState(true)
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,7 +2,7 @@ import type React from "react"
 import type { Metadata } from "next"
 import { Inter } from "next/font/google"
 import "./globals.css"
-import { AuthProvider } from "@/hooks/useAuth"
+import { PrestashopAuthProvider } from "@/hooks/usePrestashopAuth"
 import { CartProvider } from "@/hooks/useCart"
 import { Toaster } from "@/components/ui/toaster"
 
@@ -22,12 +22,12 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <AuthProvider>
+        <PrestashopAuthProvider>
           <CartProvider>
             {children}
             <Toaster />
           </CartProvider>
-        </AuthProvider>
+        </PrestashopAuthProvider>
       </body>
     </html>
   )

--- a/components/auth/AuthModal.tsx
+++ b/components/auth/AuthModal.tsx
@@ -9,7 +9,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
-import { useAuth } from "@/hooks/useAuth"
+import { usePrestashopAuth } from "@/hooks/usePrestashopAuth"
 import { useToast } from "@/hooks/use-toast"
 
 interface AuthModalProps {
@@ -21,7 +21,7 @@ interface AuthModalProps {
 export function AuthModal({ isOpen, onClose, defaultTab = "login" }: AuthModalProps) {
   const [showPassword, setShowPassword] = useState(false)
   const [isLoading, setIsLoading] = useState(false)
-  const { login, register } = useAuth()
+  const { login, register } = usePrestashopAuth()
   const { toast } = useToast()
 
   const [loginForm, setLoginForm] = useState({

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -13,7 +13,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu"
-import { useAuth } from "@/hooks/useAuth"
+import { usePrestashopAuth } from "@/hooks/usePrestashopAuth"
 import { useCart } from "@/hooks/useCart"
 import { AuthModal } from "@/components/auth/AuthModal"
 import { CartDrawer } from "@/components/cart/CartDrawer"
@@ -21,7 +21,7 @@ import { CartDrawer } from "@/components/cart/CartDrawer"
 export function Header() {
   const [authModalOpen, setAuthModalOpen] = useState(false)
   const [authModalTab, setAuthModalTab] = useState<"login" | "register">("login")
-  const { state: authState, logout } = useAuth()
+  const { state: authState, logout } = usePrestashopAuth()
   const { state: cartState, toggleCart } = useCart()
 
   const handleAuthClick = (tab: "login" | "register") => {


### PR DESCRIPTION
## Summary
- switch to `PrestashopAuthProvider` in root layout
- update `Header` and `AuthModal` to use Prestashop auth
- use Prestashop auth in account pages

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840386acc8483308a27e2c9c161181f